### PR TITLE
cleaned up the file loading loop

### DIFF
--- a/scripts/start.rb
+++ b/scripts/start.rb
@@ -2,15 +2,11 @@ SCREENWIDTH = 480
 SCREENHEIGHT = 320
 Graphics.resize_screen(SCREENWIDTH, SCREENHEIGHT)
 
-#files = Dir.glob(File.join('.', '**', '*.rb')).map { |f| File.expand_path(f) }
-#files.sort.each { |f| Kernel.send(:require, f) }
-txt = File.open('scripts/_order.rb') { |f| f.read }
-txt.gsub!(/\r/, '')
-for e in txt.split("\n")
-  file = e.split(':')[0]
-  name = e.split(':')[1..-1].join(':')
-  name = name[1..-1] while name[0] == ' '
-  Kernel.send(:require, File.expand_path("scripts/" + file))
+scripts = File.open('scripts/_order.rb').read
+scripts.each_line do |line|
+  file, *name = line.split(':')
+  name = name.join(' ').strip.chomp
+  Kernel.send(:require, File.expand_path("scripts/#{file}"))
 end
 
 abort


### PR DESCRIPTION
this wasn't the nicest way of doing loads and also a little inefficient, doing things like continually re-splitting the line on ":" instead of just using a splat operator, and using while to kill leading spaces. it's not noticeable now but this could easily get to be a problem as our codebase grows to be much larger.